### PR TITLE
Fix return

### DIFF
--- a/src/Requests/PaymayaRequest.php
+++ b/src/Requests/PaymayaRequest.php
@@ -6,6 +6,6 @@ abstract class PaymayaRequest
 {
     public static function make(): self
     {
-        return self;
+        return new static();
     }
 }

--- a/tests/Vault/CustomerApiTest.php
+++ b/tests/Vault/CustomerApiTest.php
@@ -25,7 +25,7 @@ class CustomerApiTest extends TestCase
     {
         $customerApi = new CustomerClient($this->generatePaymayaClient());
 
-        $buyer = (new Buyer())
+        $buyer =  Buyer::make()
             ->setFirstName($buyerData['firstName'])
             ->setMiddleName($buyerData['middleName'])
             ->setLastName($buyerData['lastName'])


### PR DESCRIPTION
php -v
 `PHP 7.4.10 `

Fixes # .

![Screenshot from 2020-10-10 09-39-44](https://user-images.githubusercontent.com/8251344/95642668-90999800-0adc-11eb-92a7-885ff6a0f1d0.png)

**What changed?**
  use `new static()` instead of `new self`


**How can it be tested?**

updated `CustomerApiTest::testRegisterACustomer()` in `Buyer::make()`

**What are possible test scenarios?**



**Add notable screenshots here for easier review**


