### PR TITLE
Chore: Remove Unused Dependency nesbot/carbon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.0 || ^7.0",
-        "nesbot/carbon": "^2.0"
+        "guzzlehttp/guzzle": "^6.0 || ^7.0"
     },
     "require-dev": {
         "dms/phpunit-arraysubset-asserts": "^0.4.0",


### PR DESCRIPTION
**What changed?**
- Removed unused dependency `nestbot/carbon` which also blocks installing this package from latest project that has `nesbot/carbon version:^3.0`



